### PR TITLE
MNT: check in misc changes from before covid

### DIFF
--- a/plc-kfe-motion/_Config/NC/Axes/Axis 1 IM1K0-XTES-MMS.xti
+++ b/plc-kfe-motion/_Config/NC/Axes/Axis 1 IM1K0-XTES-MMS.xti
@@ -1331,7 +1331,7 @@ External Setpoint Generation:
 		</AxisPara>
 		<Encoder Name="Enc" EncType="7">
 			<EncPara ScaleFactorNumerator="0.002777099609" Offset="-91" MaxCount="#x0000ffff" ReferenceSystem="1">
-				<SoftEndMinControl Enable="true" Range="-89"/>
+				<SoftEndMinControl Enable="true" Range="-90"/>
 				<SoftEndMaxControl Enable="true"/>
 				<Inc RefSoftSyncMask="#x0000ffff"/>
 			</EncPara>

--- a/plc-kfe-motion/_Config/NC/Axes/Axis 5 IM2K0-XTES-MMS.xti
+++ b/plc-kfe-motion/_Config/NC/Axes/Axis 5 IM2K0-XTES-MMS.xti
@@ -1373,10 +1373,9 @@ External Setpoint Generation:
 			</Vars>
 		</Encoder>
 		<Drive Name="Drive" DrvType="24">
-			<DrvPara>
+			<DrvPara Inverse="true">
 				<Analog VeloReferenz="50" ScaleFactorActTorque="0.1"/>
 				<TimeComp TaskDelayCycles="1"/>
-				<ParameterChanged>6</ParameterChanged>
 			</DrvPara>
 			<Vars VarGrpType="1">
 				<Name>Inputs</Name>

--- a/plc-kfe-motion/plc-kfe-motion.tsproj
+++ b/plc-kfe-motion/plc-kfe-motion.tsproj
@@ -2,6 +2,11 @@
 <TcSmProject xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2012/07/TcSmProject" TcSmVersion="1.0" TcVersion="3.1.4022.30">
 	<Project ProjectGUID="{63CBF008-0762-41FB-908E-CCE4E38CC038}" TargetNetId="172.21.92.58.1.1" ShowHideConfigurations="#x306">
 		<System>
+			<Licenses CacheOrCheckLicensesOnStartup="true">
+				<Target>
+					<LicenseDevice DongleHardwareId="2" DongleDevice="#x03020007" DongleSystemId="{A5386D4B-7B21-7243-FFC5-0503E4719F99}"/>
+				</Target>
+			</Licenses>
 			<Tasks>
 				<Task Id="5" Priority="20" CycleTime="100000" AmsPort="350" AdtTasks="true">
 					<Name>PlcTask</Name>


### PR DESCRIPTION
It looks like at some point I:
- Expanded the lower limit of IM1K0 from -89 to -90
- Inverted the Y motor for IM2K0 (included in #25)
- Set up the licence dongle

I'd like to merge now to keep everything in sync