### PR TITLE
MNT: remove limits from lens motors as was intended.

### DIFF
--- a/plc-kfe-motion/_Config/NC/Axes/Axis 31 IM1K4-XTES-CLZ.xti
+++ b/plc-kfe-motion/_Config/NC/Axes/Axis 31 IM1K4-XTES-CLZ.xti
@@ -1330,8 +1330,6 @@ External Setpoint Generation:
 		</AxisPara>
 		<Encoder Name="Enc" EncType="4">
 			<EncPara ScaleFactorNumerator="0.003" MaxCount="#x0000ffff">
-				<SoftEndMinControl Enable="true" Range="-100"/>
-				<SoftEndMaxControl Enable="true" Range="100"/>
 				<Inc RefSoftSyncMask="#x0000ffff"/>
 			</EncPara>
 			<Vars VarGrpType="1">

--- a/plc-kfe-motion/_Config/NC/Axes/Axis 32 IM1K4-XTES-CLF.xti
+++ b/plc-kfe-motion/_Config/NC/Axes/Axis 32 IM1K4-XTES-CLF.xti
@@ -1330,8 +1330,6 @@ External Setpoint Generation:
 		</AxisPara>
 		<Encoder Name="Enc" EncType="4">
 			<EncPara ScaleFactorNumerator="0.008" MaxCount="#x0000ffff">
-				<SoftEndMinControl Enable="true" Range="-100"/>
-				<SoftEndMaxControl Enable="true" Range="100"/>
 				<Inc RefSoftSyncMask="#x0000ffff"/>
 			</EncPara>
 			<Vars VarGrpType="1">


### PR DESCRIPTION
This was done on all lens sets except from IM1K4
This is safe due to how the lens controls react to end of travel and desirable in case they lose position