### PR TITLE
MNT: missed one nTran, potential damage

### DIFF
--- a/plc-kfe-motion/kfe_motion/POUs/PRG_IM2K0_XTES.TcPOU
+++ b/plc-kfe-motion/kfe_motion/POUs/PRG_IM2K0_XTES.TcPOU
@@ -26,7 +26,7 @@ fbIM2K0.stYag.fPosition := -87.65;
 fbIM2K0.stYag.bUseRawCounts := FALSE;
 fbIM2K0.stYag.nRequestAssertionID := 16#2202;
 fbIM2K0.stYag.stBeamParams := PMPS_GVL.cstFullBeam;
-fbIM2K0.stYag.stBeamParams.nTran := 20;
+fbIM2K0.stYag.stBeamParams.nTran := 0.2;
 fbIM2K0.stYag.bValid := TRUE;
 
 fbIM2K0.stDiamond.fPosition := -57.65;


### PR DESCRIPTION
With pmps v2.0.0, nTran changed from an integer between 1 and 100 to a float between 0 and 1. This particular instance of 20% transmission was kept at 20 instead of being reduced to 0.2, as done in this PR, meaning that this device was not actually protected from full beam.

This may have contributed to the mark on IM2K0's YAG during the incident on July 6th.
This was missed and should have been done in #79 