### PR TITLE
ENH: Adding MR1K1 to veto IM1K4, AT1K4 and IM1K3 in Fee motion

### DIFF
--- a/plc-kfe-motion/kfe_motion/GVLs/GVL.TcGVL
+++ b/plc-kfe-motion/kfe_motion/GVLs/GVL.TcGVL
@@ -3,8 +3,10 @@
   <GVL Name="GVL" Id="{53ff6662-fc6b-4a00-9f46-186d8230905b}">
     <Declaration><![CDATA[{attribute 'qualified_only'}
 VAR_GLOBAL
-    {attribute 'pytmc' := 'pv: PLC:KFE:MOTION:ARB'}
+    {attribute 'pytmc' := 'pv: PLC:KFE:MOTION:ARB:01'}
     fbArbiter: FB_Arbiter(1);
+	{attribute 'pytmc' := 'pv: PLC:KFE:MOTION:ARB:02'}
+    fbArbiter2: FB_Arbiter(2);
     {attribute 'pytmc' := 'pv: PLC:KFE:MOTION:FFO:01'}
     {attribute 'TcLinkTo' := '.q_xFastFaultOut:=TIIB[PMPS_FFO]^Channel 1^Output'}
     fbFastFaultOutput1: FB_HardwareFFOutput := (bAutoReset := TRUE, i_sNetID:='172.21.92.73.1.1');

--- a/plc-kfe-motion/kfe_motion/POUs/PRG_3_PMPS_POST.TcPOU
+++ b/plc-kfe-motion/kfe_motion/POUs/PRG_3_PMPS_POST.TcPOU
@@ -4,15 +4,30 @@
     <Declaration><![CDATA[PROGRAM PRG_3_PMPS_POST
 VAR
     fbArbiterIO: FB_SubSysToArbiter_IO;
+	fb_vetoArbiter: FB_VetoArbiter;
+	bM1K1_Veto_IN: BOOL;
 END_VAR
 ]]></Declaration>
     <Implementation>
-      <ST><![CDATA[GVL.fbFastFaultOutput1.Execute();
-GVL.fbFastFaultOutput2.Execute();
+      <ST><![CDATA[// create MR1K1 as veto for K4 lines
+bM1K1_Veto_IN := NOT PMPS_GVL.stCurrentBeamParameters.aVetoDevices[PMPS.K_Stopper.MR1K1_OUT] 
+                AND PMPS_GVL.stCurrentBeamParameters.aVetoDevices[PMPS.K_Stopper.MR1K1_IN];
+//create a preemptive request from Arbiter 2 in Arbiter 1
+fb_vetoArbiter(bVeto:=bM1K1_Veto_IN,
+                HigherAuthority := GVL.fbArbiter,
+                LowerAuthority := GVL.fbArbiter2,
+                FFO := GVL.fbFastFaultOutput2);
 
+
+
+GVL.fbFastFaultOutput1.Execute();
+//GVL.fbFastFaultOutput2.Execute();
+GVL.fbFastFaultOutput2.Execute(i_xVeto:=bM1K1_Veto_IN);   
 fbArbiterIO(
     Arbiter:=GVL.fbArbiter,
-    fbFFHWO:=GVL.fbFastFaultOutput1);]]></ST>
+    fbFFHWO:=GVL.fbFastFaultOutput1);
+	
+]]></ST>
     </Implementation>
   </POU>
 </TcPlcObject>

--- a/plc-kfe-motion/kfe_motion/POUs/PRG_AT1K4_SOLID.TcPOU
+++ b/plc-kfe-motion/kfe_motion/POUs/PRG_AT1K4_SOLID.TcPOU
@@ -184,7 +184,7 @@ fbStage1.stFilter8.bMoveOk                 := TRUE;
 fbStage1.arrFilters[8].fFilterThickness_um := 20;
 fbStage1.arrFilters[8].sFilterMaterial     := 'Si';
 
-fbStage1(stAxis:=Main.M26, nEnableMode:=nEnableMode, fbFFHWO:=GVL.fbFastFaultOutput1);
+fbStage1(stAxis:=Main.M26, nEnableMode:=nEnableMode, fbFFHWO:=GVL.fbFastFaultOutput2);
 
 
 (* State setup - stage 2 *)
@@ -268,7 +268,7 @@ fbStage2.stFilter8.bMoveOk                 := TRUE;
 fbStage2.arrFilters[8].fFilterThickness_um := 10;
 fbStage2.arrFilters[8].sFilterMaterial     := 'Si';
 
-fbStage2(stAxis:=Main.M27, nEnableMode:=nEnableMode, fbFFHWO:=GVL.fbFastFaultOutput1);
+fbStage2(stAxis:=Main.M27, nEnableMode:=nEnableMode, fbFFHWO:=GVL.fbFastFaultOutput2);
 
 
 (* State setup - stage 3 *)
@@ -352,7 +352,7 @@ fbStage3.stFilter8.bMoveOk                 := TRUE;
 fbStage3.arrFilters[8].fFilterThickness_um := 6;
 fbStage3.arrFilters[8].sFilterMaterial     := 'C';
 
-fbStage3(stAxis:=Main.M28, nEnableMode:=nEnableMode, fbFFHWO:=GVL.fbFastFaultOutput1);
+fbStage3(stAxis:=Main.M28, nEnableMode:=nEnableMode, fbFFHWO:=GVL.fbFastFaultOutput2);
 
 
 (* State setup - stage 4 *)
@@ -436,7 +436,7 @@ fbStage4.stFilter8.bMoveOk                 := TRUE;
 fbStage4.arrFilters[8].fFilterThickness_um := 0.2;
 fbStage4.arrFilters[8].sFilterMaterial     := 'Al';
 
-fbStage4(stAxis:=Main.M29, nEnableMode:=nEnableMode, fbFFHWO:=GVL.fbFastFaultOutput1);
+fbStage4(stAxis:=Main.M29, nEnableMode:=nEnableMode, fbFFHWO:=GVL.fbFastFaultOutput2);
 
 GVL.rCurTrans[PMPS.K_Attenuators.AT1K4].nTran := LREAL_TO_REAL(
     fbStage1.fTransmission *

--- a/plc-kfe-motion/kfe_motion/POUs/PRG_IM1K3_PPM.TcPOU
+++ b/plc-kfe-motion/kfe_motion/POUs/PRG_IM1K3_PPM.TcPOU
@@ -50,7 +50,7 @@ fbIM1K3.stYag2.stBeamParams := PMPS_GVL.cstFullBeam;
 fbIM1K3.stYag2.bValid := TRUE;
 
 fbIM1K3(
-    fbArbiter := GVL.fbArbiter,
+    fbArbiter := GVL.fbArbiter2,
     fbFFHWO := GVL.fbFastFaultOutput2,
     stYStage := Main.M4);
 ]]></ST>

--- a/plc-kfe-motion/kfe_motion/POUs/PRG_IM1K4_XTES.TcPOU
+++ b/plc-kfe-motion/kfe_motion/POUs/PRG_IM1K4_XTES.TcPOU
@@ -93,8 +93,8 @@ fbIM1K4.stReticle.stBeamParams := PMPS_GVL.cst0RateBeam;
 fbIM1K4.stReticle.bValid := TRUE;
 
 fbIM1K4(
-    fbArbiter := GVL.fbArbiter,
-    fbFFHWO := GVL.fbFastFaultOutput1,
+    fbArbiter := GVL.fbArbiter2,
+    fbFFHWO := GVL.fbFastFaultOutput2,
     stYStage := Main.M30,
     stZoomStage := Main.M31,
     stFocusStage := Main.M32,


### PR DESCRIPTION
1.create a preemptive request from Arbiter 2 in Arbiter 1
2. Add MR1K1 Veto K4 line and IM1K3