### PR TITLE
removing the old fbFastFaultOutput2 execute

### DIFF
--- a/plc-kfe-motion/kfe_motion/POUs/PRG_3_PMPS_POST.TcPOU
+++ b/plc-kfe-motion/kfe_motion/POUs/PRG_3_PMPS_POST.TcPOU
@@ -21,7 +21,7 @@ fb_vetoArbiter(bVeto:=bM1K1_Veto_IN,
 
 
 GVL.fbFastFaultOutput1.Execute();
-//GVL.fbFastFaultOutput2.Execute();
+
 GVL.fbFastFaultOutput2.Execute(i_xVeto:=bM1K1_Veto_IN);   
 fbArbiterIO(
     Arbiter:=GVL.fbArbiter,


### PR DESCRIPTION
According to Zach comments, we delete the old code GVL.fbFastFaultOutput2.Execute()